### PR TITLE
Fix login fallback credentials

### DIFF
--- a/src/com/mycompany/polloloco/dao/UsuarioDAO.java
+++ b/src/com/mycompany/polloloco/dao/UsuarioDAO.java
@@ -68,7 +68,20 @@ public class UsuarioDAO {
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) return Optional.of(mapRow(rs));
             }
-        } catch (SQLException ex) { LOG.log(Level.SEVERE, "login", ex); }
+        } catch (SQLException ex) {
+            LOG.log(Level.SEVERE, "login", ex);
+        }
+
+        // --- Fallback a credenciales por defecto si BD no responde o no coincide ---
+        if ("admin".equals(usr) && "1234".equals(plainPass)) {
+            Usuario u = new Usuario();
+            u.setId(0);
+            u.setNombre("Administrador");
+            u.setUsuario("admin");
+            u.setClaveHash(hash("1234"));
+            u.setIdRol(1);
+            return Optional.of(u);
+        }
         return Optional.empty();
     }
 


### PR DESCRIPTION
## Summary
- add fallback admin credentials in case DB login fails

## Testing
- `ant -noinput -q test` *(fails: compiler error)*

------
https://chatgpt.com/codex/tasks/task_e_6881e1e24ec88324a18dee9f52d2fae9